### PR TITLE
DEV-622 [FIX] Show error and hide save button when widget is outside LFD.

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -1,7 +1,22 @@
 Fliplet.Widget.findParents({ filter: { package: 'com.fliplet.dynamic-container' } }).then(function(widgets) {
   const dynamicContainer = widgets[0];
 
-  return Fliplet.DataSources.getById(dynamicContainer && dynamicContainer.dataSourceId, {
+  if (widgets.length === 0 || !dynamicContainer.dataSourceId) {
+    Fliplet.Widget.generateInterface({
+      title: 'Configure data files',
+      fields: [
+        {
+          type: 'html',
+          html: '<p style="color: #A5A5A5; font-size: 12px; font-weight: 400;">This component needs to be placed inside a Data container with selected Data source</p>'
+        }
+      ]
+    });
+
+    return Fliplet.UI.Toast('This component needs to be placed inside a Data container with selected Data source');
+  }
+
+
+  return Fliplet.DataSources.getById(dynamicContainer.dataSourceId, {
     attributes: ['columns']
   }).then((dataSource) => {
     return _.orderBy(dataSource.columns, column => column.toLowerCase());


### PR DESCRIPTION
### Product areas affected

Fliplet Widget Files

### What does this PR do?

Show error and hide save button when widget is outside LFD.

### JIRA ticket

[DEV-622](https://weboo.atlassian.net/browse/DEV-622)

[DEV-622]: https://weboo.atlassian.net/browse/DEV-622?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Adds a clear “Configure data files” screen with an explanatory message and a toast when no widget or data source is set, guiding users to complete setup.

* Bug Fixes
  * Prevents errors and blank states by validating widget context and data source before loading.
  * Ensures the interface only proceeds when a valid data source is available, maintaining the existing flow otherwise.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->